### PR TITLE
Add gnutls-native to the u-boot-variscite dependencies

### DIFF
--- a/recipes-bsp/u-boot/u-boot-variscite.bb
+++ b/recipes-bsp/u-boot/u-boot-variscite.bb
@@ -6,7 +6,7 @@ SUMMARY = "U-Boot for Variscite's i.MX boards"
 require recipes-bsp/u-boot/u-boot.inc
 
 PROVIDES += "u-boot"
-DEPENDS += "bison-native bc-native dtc-native"
+DEPENDS += "bison-native bc-native dtc-native gnutls-native"
 FILESEXTRAPATHS:prepend := "${THISDIR}/u-boot-fw-utils:"
 
 include u-boot-common.inc


### PR DESCRIPTION
While building the new kirkstone release for the var-som-imx8mp, we got the following 
build failure from the u-boot-variscite package

```
| ../tools/mkeficapsule.c:21:10: fatal error: gnutls/gnutls.h: No such file or directory
|    21 | #include <gnutls/gnutls.h>
```

Adding gnutls-native to the dependencies fixed the build