### PR TITLE
imx6ul-var-dart.conf: fix tune-cortexa7.inc path

### DIFF
--- a/conf/machine/imx6ul-var-dart.conf
+++ b/conf/machine/imx6ul-var-dart.conf
@@ -8,7 +8,7 @@
 
 MACHINEOVERRIDES =. "mx6ul:"
 require conf/machine/include/imx-base.inc
-require conf/machine/include/tune-cortexa7.inc
+require conf/machine/include/arm/armv7a/tune-cortexa7.inc
 
 require variscite.inc
 require variscite_bcm43xx.inc


### PR DESCRIPTION
Since 'conf/machine: move tune files to architecture directories' path is now meta/conf/machine/include/arm/armv7a/tune-cortexa7.inc

Signed-off-by: Tim Orling <tim.orling@konsulko.com>