### PR TITLE
variscite_ubi.inc: IMAGE_DEPENDS on bc-native

### DIFF
--- a/conf/machine/variscite_ubi.inc
+++ b/conf/machine/variscite_ubi.inc
@@ -26,6 +26,8 @@ IMAGE_FSTYPES = "tar.gz multiubi wic.gz"
 IMAGE_TYPEDEP:multiubi += "${IMAGE_FSTYPES}"
 IMAGE_TYPEDEP:multiubi:remove = "multiubi"
 
+IMAGE_DEPENDS:multiubi += "bc-native"
+
 multiubi_mkfs:prepend() {
 	# Update PEB size in fw_env.config (u-boot-fw-utils)
 	if [ -f ${IMAGE_ROOTFS}${sysconfdir}/fw_env.config ]; then


### PR DESCRIPTION
Because multiubi_mkfs:prepend() pipes to 'bc', we need to add 'bc-native' to IMAGE_DEPENDS:multiubi (rather than DEPENDS, which is global and causes dependency loops).

Signed-off-by: Tim Orling <tim.orling@konsulko.com>