### PR TITLE
libubootenv: Move u-boot-default-env recommendation to machine conf

### DIFF
--- a/conf/machine/variscite.inc
+++ b/conf/machine/variscite.inc
@@ -59,6 +59,7 @@ MACHINE_EXTRA_RDEPENDS += " \
 	wireless-regdb-static \
 	u-boot-fw-utils \
 	u-boot-splash \
+	u-boot-default-env \
 "
 
 # Packages added to all images (including core-image-minimal)

--- a/recipes-bsp/u-boot/libubootenv_%.bbappend
+++ b/recipes-bsp/u-boot/libubootenv_%.bbappend
@@ -3,5 +3,3 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI:append = " file://0001-uboot_env-extend-line-length-to-4096.patch"
 
 LDFLAGS:append = "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-gold', " -fuse-ld=bfd ", '', d)}"
-
-RRECOMMENDS:${PN} += "u-boot-default-env"


### PR DESCRIPTION
This ensures that the layer can be part of multi-BSP setup and also have the needed functionality for variscite machines. Moreover thats the recommended way of adding u-boot-default-env to images.

Signed-off-by: Khem Raj <raj.khem@gmail.com>