### PR TITLE
Accept newer releases 4.1 and 4.2 also

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "variscite-bsp"
 BBFILE_PATTERN_variscite-bsp:= "^${LAYERDIR}/"
 BBFILE_PRIORITY_variscite-bsp= "9"
 
-LAYERSERIES_COMPAT_variscite-bsp= "kirkstone"
+LAYERSERIES_COMPAT_variscite-bsp= "kirkstone langdale"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "variscite-bsp"
 BBFILE_PATTERN_variscite-bsp:= "^${LAYERDIR}/"
 BBFILE_PRIORITY_variscite-bsp= "9"
 
-LAYERSERIES_COMPAT_variscite-bsp= "kirkstone langdale"
+LAYERSERIES_COMPAT_variscite-bsp= "kirkstone langdale mickledore"

--- a/conf/machine/variscite.inc
+++ b/conf/machine/variscite.inc
@@ -21,7 +21,6 @@ PREFERRED_RPROVIDER_u-boot-default-env ?= "u-boot-variscite"
 
 # Use i.MX Gstreamer Version
 MACHINE_GSTREAMER_1_0_PLUGIN:mx8-nxp-bsp = "imx-gst1.0-plugin"
-PREFERRED_VERSION_imx-gst1.0-plugin:mx8-nxp-bsp ?= "4.7.0"
 PREFERRED_VERSION_gstreamer1.0:mx8-nxp-bsp              ?= "1.20.0.imx"
 PREFERRED_VERSION_gstreamer1.0-plugins-base:mx8-nxp-bsp ?= "1.20.0.imx"
 PREFERRED_VERSION_gstreamer1.0-plugins-good:mx8-nxp-bsp ?= "1.20.0.imx"

--- a/conf/machine/variscite.inc
+++ b/conf/machine/variscite.inc
@@ -26,9 +26,9 @@ PREFERRED_VERSION_gstreamer1.0:mx8-nxp-bsp              ?= "1.20.0.imx"
 PREFERRED_VERSION_gstreamer1.0-plugins-base:mx8-nxp-bsp ?= "1.20.0.imx"
 PREFERRED_VERSION_gstreamer1.0-plugins-good:mx8-nxp-bsp ?= "1.20.0.imx"
 PREFERRED_VERSION_gstreamer1.0-plugins-bad:mx8-nxp-bsp  ?= "1.20.0.imx"
-PREFERRED_VERSION_gstreamer1.0-plugins-ugly:mx8-nxp-bsp ?= "1.20.0"
-PREFERRED_VERSION_gstreamer1.0-libav:mx8-nxp-bsp        ?= "1.20.0"
-PREFERRED_VERSION_gstreamer1.0-rtsp-server:mx8-nxp-bsp  ?= "1.20.0"
+PREFERRED_VERSION_gstreamer1.0-plugins-ugly:mx8-nxp-bsp ?= "1.20.%"
+PREFERRED_VERSION_gstreamer1.0-libav:mx8-nxp-bsp        ?= "1.20.%"
+PREFERRED_VERSION_gstreamer1.0-rtsp-server:mx8-nxp-bsp  ?= "1.20.%"
 
 # Add VPU and Cortex M4/M7 firmware
 MACHINE_FIRMWARE:append:mx8-nxp-bsp = " \

--- a/recipes-bsp/imx-atf/imx-atf/0001-Makefile-Suppress-array-bounds-error.patch
+++ b/recipes-bsp/imx-atf/imx-atf/0001-Makefile-Suppress-array-bounds-error.patch
@@ -1,0 +1,47 @@
+From 85f576054a4d5496706bbd37a520942f51cb74b9 Mon Sep 17 00:00:00 2001
+From: Tom Hochstein <tom.hochstein@nxp.com>
+Date: Mon, 16 May 2022 13:45:16 -0500
+Subject: [PATCH] Makefile: Suppress array-bounds error
+
+The array-bounds error is triggered now in cases where it was silent
+before, causing errors like:
+
+```
+plat/imx/imx8m/hab.c: In function 'imx_hab_handler':
+plat/imx/imx8m/hab.c:64:57: error: array subscript 0 is outside array bounds of 'uint32_t[0]' {aka 'unsigned int[]'} [-Werror=array-bounds]
+   64 | #define HAB_RVT_CHECK_TARGET_ARM64      ((unsigned long)*(uint32_t *)(HAB_RVT_BASE + 0x18))
+      |                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+The error is a false-positive and is entered as a bug [1]. The problem
+is fixed partially in GCC 12 and fully in GCC 13 [2].
+
+The partial fix does not work here because the constant addresses used
+are less than the 4kB boundary chosen for the partial fix, so suppress
+the error until GCC is upgraded to 13.
+
+[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99578
+[2] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99578#c39
+
+Upstream-Status: Inappropriate [other]
+Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index c87c3ae08..2d6b90f47 100644
+--- a/Makefile
++++ b/Makefile
+@@ -346,7 +346,7 @@ WARNINGS	+=		-Wshift-overflow -Wshift-sign-overflow \
+ endif
+ 
+ ifneq (${E},0)
+-ERRORS := -Werror
++ERRORS := -Werror -Wno-error=array-bounds
+ endif
+ 
+ CPPFLAGS		=	${DEFINES} ${INCLUDES} ${MBEDTLS_INC} -nostdinc	\
+-- 
+2.17.1
+

--- a/recipes-bsp/imx-atf/imx-atf/rwx-segments.patch
+++ b/recipes-bsp/imx-atf/imx-atf/rwx-segments.patch
@@ -1,0 +1,38 @@
+Binutils 2.39 now warns when a segment has RXW permissions[1]:
+
+aarch64-none-elf-ld.bfd: warning: bl31.elf has a LOAD segment with RWX
+permissions
+
+However, TF-A passes --fatal-warnings to LD, so this is a build failure.
+
+There is a ticket filed upstream[2], so until that is resolved just
+remove --fatal-warnings.
+
+[1] https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=ba951afb99912da01a6e8434126b8fac7aa75107
+[2] https://developer.trustedfirmware.org/T996
+
+Upstream-Status: Inappropriate
+Signed-off-by: Ross Burton <ross.burton@arm.com>
+
+diff --git a/Makefile b/Makefile
+index 3941f8698..13bbac348 100644
+--- a/Makefile
++++ b/Makefile
+@@ -418,7 +418,7 @@ TF_LDFLAGS		+=	$(TF_LDFLAGS_$(ARCH))
+ # LD = gcc (used when GCC LTO is enabled)
+ else ifneq ($(findstring gcc,$(notdir $(LD))),)
+ # Pass ld options with Wl or Xlinker switches
+-TF_LDFLAGS		+=	-Wl,--fatal-warnings -O1
++TF_LDFLAGS		+=	-O1
+ TF_LDFLAGS		+=	-Wl,--gc-sections
+ ifeq ($(ENABLE_LTO),1)
+ 	ifeq (${ARCH},aarch64)
+@@ -435,7 +435,7 @@ TF_LDFLAGS		+=	$(subst --,-Xlinker --,$(TF_LDFLAGS_$(ARCH)))
+ 
+ # LD = gcc-ld (ld) or llvm-ld (ld.lld) or other
+ else
+-TF_LDFLAGS		+=	--fatal-warnings -O1
++TF_LDFLAGS		+=	-O1
+ TF_LDFLAGS		+=	--gc-sections
+ # ld.lld doesn't recognize the errata flags,
+ # therefore don't add those in that case

--- a/recipes-bsp/imx-atf/imx-atf_2.6.bbappend
+++ b/recipes-bsp/imx-atf/imx-atf_2.6.bbappend
@@ -1,4 +1,9 @@
-SRC_URI = "git://github.com/varigit/imx-atf;protocol=https;branch=${SRCBRANCH}"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI = "git://github.com/varigit/imx-atf;protocol=https;branch=${SRCBRANCH} \
+           file://0001-Makefile-Suppress-array-bounds-error.patch \
+           file://rwx-segments.patch \
+"
 SRCBRANCH = "lf_v2.6_var01"
 SRCREV = "b15d97961fd1a921624a645aef9f2e10ef54b36c"
 

--- a/recipes-connectivity/bluealsa/bluealsa_git.bbappend
+++ b/recipes-connectivity/bluealsa/bluealsa_git.bbappend
@@ -1,5 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
+SRC_URI += "file://bluealsa.service"
+
 do_install:append () {
     install -d ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/bluealsa.service ${D}${systemd_unitdir}/system


### PR DESCRIPTION
These releases of upstream yocto work fine with kirkstone branch. Therefore we can support them on single kirkstone branch without affecting the kirkstone LTS release which is officially supported by variscite.