### PR TITLE
variscite: Enable optee machine feature on iMX8 based machines

### DIFF
--- a/conf/machine/variscite.inc
+++ b/conf/machine/variscite.inc
@@ -10,6 +10,9 @@ KERNEL_IMAGETYPE:mx8-nxp-bsp = "Image.gz"
 
 WKS_FILE:mx8-nxp-bsp = "imx-imx-boot-singlepart.wks.in"
 
+# Enable optee on iMX8 BSPs
+MACHINE_FEATURES:append:use-nxp-bsp = " optee"
+
 # Set a more generic tuning for code reuse across parts
 DEFAULTTUNE:mx8-nxp-bsp:fslc     ?= "armv8a-crc-crypto"
 DEFAULTTUNE:mx8m-nxp-bsp:fslc    ?= "armv8a-crc-crypto"


### PR DESCRIPTION
This picks up correct optee implementation which otherwise is randomly picked from meta-arm in a multi-BSP setup

Signed-off-by: Khem Raj <raj.khem@gmail.com>