### PR TITLE
variscite: Drop setting preferred gstreamer version

### DIFF
--- a/conf/machine/variscite.inc
+++ b/conf/machine/variscite.inc
@@ -21,13 +21,6 @@ PREFERRED_RPROVIDER_u-boot-default-env ?= "u-boot-variscite"
 
 # Use i.MX Gstreamer Version
 MACHINE_GSTREAMER_1_0_PLUGIN:mx8-nxp-bsp = "imx-gst1.0-plugin"
-PREFERRED_VERSION_gstreamer1.0:mx8-nxp-bsp              ?= "1.20.0.imx"
-PREFERRED_VERSION_gstreamer1.0-plugins-base:mx8-nxp-bsp ?= "1.20.0.imx"
-PREFERRED_VERSION_gstreamer1.0-plugins-good:mx8-nxp-bsp ?= "1.20.0.imx"
-PREFERRED_VERSION_gstreamer1.0-plugins-bad:mx8-nxp-bsp  ?= "1.20.0.imx"
-PREFERRED_VERSION_gstreamer1.0-plugins-ugly:mx8-nxp-bsp ?= "1.20.%"
-PREFERRED_VERSION_gstreamer1.0-libav:mx8-nxp-bsp        ?= "1.20.%"
-PREFERRED_VERSION_gstreamer1.0-rtsp-server:mx8-nxp-bsp  ?= "1.20.%"
 
 # Add VPU and Cortex M4/M7 firmware
 MACHINE_FIRMWARE:append:mx8-nxp-bsp = " \


### PR DESCRIPTION
master has 1.20.x and meta-freescale has 1.20.0-imx we depend on meta-freescale and its higher priority then core layer so it will automatically be picking up 1.20.0.imx recipes

This allows us to use kirkstone branch with master branch of meta-freescale and poky where these versions have moved to 1.20.5.imx and 1.20.5 repectively.

Signed-off-by: Khem Raj <raj.khem@gmail.com>