### PR TITLE
variscite.inc: Add PREFERRED_CONNECTIVITY_MANAGER variable.

### DIFF
--- a/conf/machine/variscite.inc
+++ b/conf/machine/variscite.inc
@@ -16,6 +16,21 @@ DEFAULTTUNE:mx8m-nxp-bsp:fslc    ?= "armv8a-crc-crypto"
 DEFAULTTUNE:mx8qxp-nxp-bsp:fslc  ?= "armv8a-crc-crypto"
 DEFAULTTUNE:mx8x-nxp-bsp:fslc    ?= "armv8a-crc-crypto"
 
+NETMAN_PACKAGES = "\
+	networkmanager \
+	networkmanager-nmcli \
+"
+
+# Wayland distros should default to networkmanager
+PREFERRED_CONNECTIVITY_MANAGER	 ?= " \
+	${@bb.utils.contains('DISTRO_FEATURES', 'wayland', \
+		'networkmanager', '', d)} \
+"
+PREFERRED_CONNECTIVITY_MANAGER_PACKAGES	?= " \
+	${@bb.utils.contains('PREFERRED_CONNECTIVITY_MANAGER', 'networkmanager', \
+		'${NETMAN_PACKAGES}','', d)} \
+"
+
 # Variscite BSP default providers
 PREFERRED_RPROVIDER_u-boot-default-env ?= "u-boot-variscite"
 
@@ -47,9 +62,7 @@ MACHINE_EXTRA_RDEPENDS += " \
 	iw \
 	kernel-modules \
 	kmod \
-	${@bb.utils.contains('DISTRO', 'b2qt', '', \
-           bb.utils.contains('DISTRO_FEATURES', 'wayland', 'networkmanager networkmanager-nmcli', \
-                                                       '', d), d)} \
+	${PREFERRED_CONNECTIVITY_MANAGER_PACKAGES} \
 	packagegroup-tools-bluetooth \
 	bluealsa \
 	pm-utils \


### PR DESCRIPTION
Currently, there are runtime dependency conflicts between networkmanager and connman. As these packages are often runtime dependencies of other packages, this can lead to build failures with various combinations of packages.

To mitigate this, introduce a new variable
PREFERRED_CONNECTIVITY_MANAGER which will allow conflicting packages to conditionally remove their connman dependency. For wayland based distros, default this to networkmanager and install as we already do today. Additionally, remove boot2qt logic for these installs since wayland is no longer relevent in boot2qt.

Signed-off-by: Ken Sloat <ken.s@variscite.com>