### PR TITLE
freertos-variscite: Clear out environment provided LDFLAGS

### DIFF
--- a/recipes-bsp/freertos-variscite/freertos-variscite.inc
+++ b/recipes-bsp/freertos-variscite/freertos-variscite.inc
@@ -89,7 +89,7 @@ compile_fw() {
     DIR_GCC="$1"
     cd ${DIR_GCC}
     ./clean.sh
-    CFLAGS="" CXXFLAGS="" ./build_all.sh > /dev/null
+    LDFLAGS="" CFLAGS="" CXXFLAGS="" ./build_all.sh > /dev/null
 }
 
 do_compile() {


### PR DESCRIPTION
LDFLAGS that bitbake env adds can bring on incompatible options like -fuse-ld=lld which will fail becasue this component uses a specific gcc specific baremetal toolchain which obviously does not have lld or any LLVM toolchain components.