### PR TITLE
systemd-networkd-wait-online: Suppress error message of ExecCondition

### DIFF
--- a/recipes-core/systemd/systemd/0002-units-disable-systemd-networkd-wait-online-if-Networ.patch
+++ b/recipes-core/systemd/systemd/0002-units-disable-systemd-networkd-wait-online-if-Networ.patch
@@ -22,8 +22,8 @@ index 10d8b08c8e..5d5c43e3f0 100644
  [Service]
  Type=oneshot
  ExecStart={{ROOTLIBEXECDIR}}/systemd-networkd-wait-online
-+ExecCondition=/bin/bash -c '! /bin/systemctl is-enabled NetworkManager-wait-online.service'
-+ExecCondition=/bin/bash -c '! /bin/systemctl is-enabled connman-wait-online.service'
++ExecCondition=/bin/bash -c '! /bin/systemctl is-enabled NetworkManager-wait-online.service 2>/dev/null'
++ExecCondition=/bin/bash -c '! /bin/systemctl is-enabled connman-wait-online.service 2>/dev/null'
  RemainAfterExit=yes
  
  [Install]


### PR DESCRIPTION
When NetworkManager and connman are not installed, the ExecCondition produces the following error message in the journal. Prevent this because it's confusing.

    bash[…]: Failed to get unit file state for NetworkManager-wait-online.service: No such file or directory