### PR TITLE
freertos-variscite: Fix compile failure when do_compile is rerun

### DIFF
--- a/recipes-bsp/freertos-variscite/freertos-variscite.inc
+++ b/recipes-bsp/freertos-variscite/freertos-variscite.inc
@@ -99,7 +99,8 @@ do_compile() {
     # Copy and patch hello_world demo to disable_cache demo
     if [ -e "${WORKDIR}/${DISABLE_CACHE_PATCH}" ]; then
         # Copy hello_world demo
-        cp -r ${S}/boards/${CM_BOARD}/demo_apps/hello_world/ ${S}/boards/${CM_BOARD}/demo_apps/disable_cache
+        mkdir -p ${S}/boards/${CM_BOARD}/demo_apps/disable_cache
+        cp -ru ${S}/boards/${CM_BOARD}/demo_apps/hello_world/* ${S}/boards/${CM_BOARD}/demo_apps/disable_cache/
         # Rename hello_world strings to disable_cache
         grep -rl hello_world ${S}/boards/${CM_BOARD}/demo_apps/disable_cache | xargs sed -i 's/hello_world/disable_cache/g'
         # Rename hello_world files to disable_cache


### PR DESCRIPTION
do_compile could be rerun on a previous built tree, the do_compile of this recipe however is doing renaming and moving of files and then assuming the pristine condition is hard because it would have run these operations in prior run, in second run it does not find the ${S}/boards/${CM_BOARD}/demo_apps/disable_cache/ dir and find cmd fails to execute

| find: ‘/mnt/b/yoe/master/build/tmp/work/imx8qm_var_som-yoe-linux/freertos-variscite/2.9.x-r0/git/boards/som_mx8qm/demo_apps/disable_cache/hello_world’: No such file or directory | WARNING: /mnt/b/yoe/master/build/tmp/work/imx8qm_var_som-yoe-linux/freertos-variscite/2.9.x-r0/temp/run.do_compile.406532:151 exit 1 from 'find /mnt/b/yoe/master/build/tmp/work/imx8qm_var_ som-yoe-linux/freertos-variscite/2.9.x-r0/git/boards/som_mx8qm/demo_apps/disable_cache/ -name '*hello_world*' -exec sh -c 'mv "$1" "$(echo "$1" | sed s/hello_world/disable_cache/)"' _ {} \;'