### PR TITLE
variscite_ubi: Do not export shell variables when not needed

### DIFF
--- a/conf/machine/variscite_ubi.inc
+++ b/conf/machine/variscite_ubi.inc
@@ -1,11 +1,11 @@
 # UBIFS for Variscite 0.5GB NAND flash
 # erase block size of 128KiB
-export MKUBIFS_ARGS_128kbpeb = " -m 2048 -e 124KiB -c 3965 "
-export UBINIZE_ARGS_128kbpeb = " -m 2048 -p 128KiB -s 2048 "
+MKUBIFS_ARGS_128kbpeb = " -m 2048 -e 124KiB -c 3965 "
+UBINIZE_ARGS_128kbpeb = " -m 2048 -p 128KiB -s 2048 "
 
 # erase block size of 256KiB
-export MKUBIFS_ARGS_256kbpeb = " -m 4096 -e 248KiB -c 2000 "
-export UBINIZE_ARGS_256kbpeb = " -m 4096 -p 256KiB -s 4096 "
+MKUBIFS_ARGS_256kbpeb = " -m 4096 -e 248KiB -c 2000 "
+UBINIZE_ARGS_256kbpeb = " -m 4096 -p 256KiB -s 4096 "
 
 # UBIFS for Variscite 1GB NAND flash
 # erase block size of 128KiB


### PR DESCRIPTION
Since this file is included by machine conf, means these variables make into all kind of recipes e.g. native, nativesdk and that makes whole sstate specific to the machine and not usable across other projects/machines. e.g. if we have imx8 and imx6 dart based products it results in recompiling everything for each of them and thus keep two copies of sstate which is inefficient.

Fixes
bitbake-diffsigs -t m4-native do_configure
Task dependencies changed from:
...
changed items: frozenset({'UBINIZE_ARGS_256kbpeb', 'MKUBIFS_ARGS_128kbpeb', 'MKUBIFS_ARGS_256kbpeb', 'UBINIZE_ARGS_128kbpeb'}) Dependency on Variable MKUBIFS_ARGS_128kbpeb was removed Dependency on Variable MKUBIFS_ARGS_256kbpeb was removed Dependency on Variable UBINIZE_ARGS_128kbpeb was removed Dependency on Variable UBINIZE_ARGS_256kbpeb was removed