### PR TITLE
Support builds with multiple U-Boot Configurations

### DIFF
--- a/recipes-bsp/u-boot/u-boot-variscite.bb
+++ b/recipes-bsp/u-boot/u-boot-variscite.bb
@@ -36,7 +36,7 @@ do_deploy:append:mx8m-nxp-bsp () {
                     for dtb in ${UBOOT_DTB_EXTRA}; do
                         install -m 0777 ${B}/${config}/arch/arm/dts/${dtb} ${DEPLOYDIR}/${BOOT_TOOLS}
                     done
-                    install -m 0777 ${B}/${config}/u-boot-nodtb.bin  ${DEPLOYDIR}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${UBOOT_CONFIG}
+                    install -m 0777 ${B}/${config}/u-boot-nodtb.bin  ${DEPLOYDIR}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${type}
                 fi
             done
             unset  j


### PR DESCRIPTION
If a user extends the Variscite-provided Yocto configuration to support multiple U-Boot configurations (see https://docs.yoctoproject.org/ref-manual/variables.html#term-UBOOT_CONFIG), then the current code will fail to build.