### PR TITLE
iw612-utils: Add rdepends on coreutils

### DIFF
--- a/recipes-connectivity/iw612-utils/iw612-utils.bbappend
+++ b/recipes-connectivity/iw612-utils/iw612-utils.bbappend
@@ -1,1 +1,3 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+RDEPENDS:${PN} += "coreutils"


### PR DESCRIPTION
After 26bd2a891ccce3ce584864d4ebeb2fc259629334, the iw612-utils has a dependency on coreutils. This patch adds it to rdepends.