### PR TITLE
Remove redundant U-Boot preferred provider settings

### DIFF
--- a/conf/machine/imx8mp-var-dart.conf
+++ b/conf/machine/imx8mp-var-dart.conf
@@ -107,9 +107,6 @@ UBOOT_SUFFIX = "bin"
 UBOOT_MAKE_TARGET = "all"
 IMX_BOOT_SEEK = "32"
 
-PREFERRED_PROVIDER_u-boot:imx8mp-var-dart = "u-boot-variscite"
-PREFERRED_PROVIDER_virtual/bootloader:imx8mp-var-dart = "u-boot-variscite"
-
 TEE_CFG_DDR_SIZE ?= "0x100000000"
 
 # Mender Configuration


### PR DESCRIPTION
Removed the redundant preferred provider settings for U-Boot that forcibly override the default settings that were created earlier in the  file.  These removed lines make it so that the default u-boot recipie can not be overridden by higher priority layers.