### PR TITLE
u-boot-variscite: Support multiple UBOOT_CONFIG entries

### DIFF
--- a/recipes-bsp/u-boot/u-boot-variscite.bb
+++ b/recipes-bsp/u-boot/u-boot-variscite.bb
@@ -37,7 +37,7 @@ do_deploy:append:mx8m-nxp-bsp () {
                     for dtb in ${UBOOT_DTB_EXTRA}; do
                         install -m 0777 ${B}/${config}/arch/arm/dts/${dtb} ${DEPLOYDIR}/${BOOT_TOOLS}
                     done
-                    install -m 0777 ${B}/${config}/u-boot-nodtb.bin  ${DEPLOYDIR}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${UBOOT_CONFIG}
+                    install -m 0777 ${B}/${config}/u-boot-nodtb.bin  ${DEPLOYDIR}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${type}
                 fi
             done
             unset  j


### PR DESCRIPTION
Current code fails if UBOOT_CONFIG contains multiple types